### PR TITLE
improve templates documentation

### DIFF
--- a/site/pages/templates/lua-sqlite.mdx
+++ b/site/pages/templates/lua-sqlite.mdx
@@ -16,6 +16,22 @@ This template demonstrates how to create a Lua process that interacts with SQLit
 ```bash
 npm install
 ```
+:::warning
+You will have to authenticate yourself to your aos process using a keyfile.
+If you dont have the aos package alredy installed, you can run the below commands
+:::
+```
+npm i -g https://get_ao.g8way.io
+```
+After installation, simply run:
+```
+aos
+```
+This will setup a new keyfile for you, and then you can export it as an environment variable
+```
+export WALLET_JSON="$(cat ~/.aos.json)"
+```
+More information can be found [here](https://cookbook_ao.g8way.io/welcome/getting-started.html#installing-aos)
 
 ### Build the Lua process
 

--- a/site/pages/templates/lua.mdx
+++ b/site/pages/templates/lua.mdx
@@ -5,7 +5,7 @@ This template provides a basic setup for developing Lua-based applications on th
 ![lua frontend](/lua.png)
 
 ## Features
-This starter template with a simple Lua Counter process. 
+This starter template with a simple Lua Counter process.
 It includes a basic Lua process that increments a counter and returns the current count.
 
 - Lua Counter Process
@@ -18,6 +18,22 @@ It includes a basic Lua process that increments a counter and returns the curren
 ```bash
 npm install
 ```
+:::warning
+You will have to authenticate yourself to your aos process using a keyfile.
+If you dont have the aos package alredy installed, you can run the below commands
+:::
+```
+npm i -g https://get_ao.g8way.io
+```
+After installation, simply run:
+```
+aos
+```
+This will setup a new keyfile for you, and then you can export it as an environment variable
+```
+export WALLET_JSON="$(cat ~/.aos.json)"
+```
+More information can be found [here](https://cookbook_ao.g8way.io/welcome/getting-started.html#installing-aos)
 
 ### Build the Lua process
 

--- a/site/pages/templates/teal-sqlite.mdx
+++ b/site/pages/templates/teal-sqlite.mdx
@@ -16,6 +16,22 @@ This template demonstrates how to build a Teal-typed Lua process that interacts 
 ```bash
 npm install
 ```
+:::warning
+You will have to authenticate yourself to your aos process using a keyfile.
+If you dont have the aos package alredy installed, you can run the below commands
+:::
+```
+npm i -g https://get_ao.g8way.io
+```
+After installation, simply run:
+```
+aos
+```
+This will setup a new keyfile for you, and then you can export it as an environment variable
+```
+export WALLET_JSON="$(cat ~/.aos.json)"
+```
+More information can be found [here](https://cookbook_ao.g8way.io/welcome/getting-started.html#installing-aos)
 
 ### Build the Lua process
 

--- a/site/pages/templates/teal.mdx
+++ b/site/pages/templates/teal.mdx
@@ -16,6 +16,22 @@ It includes a basic Teal process that increments a counter and returns the curre
 ```bash
 npm install
 ```
+:::warning
+You will have to authenticate yourself to your aos process using a keyfile.
+If you dont have the aos package alredy installed, you can run the below commands
+:::
+```
+npm i -g https://get_ao.g8way.io
+```
+After installation, simply run:
+```
+aos
+```
+This will setup a new keyfile for you, and then you can export it as an environment variable
+```
+export WALLET_JSON="$(cat ~/.aos.json)"
+```
+More information can be found [here](https://cookbook_ao.g8way.io/welcome/getting-started.html#installing-aos)
 
 ### Build the Lua process
 


### PR DESCRIPTION
## Summary
Improves the documentation for the templates in [ao-cookbook](https://www.ao-create-dapp.dev/#/).

### Problem Statement
Currently, if someone follows the steps without having [aos](https://cookbook_ao.g8way.io/welcome/getting-started.html#installing-aos) installed, they will encounter an error when trying to build the Lua Process:

![Error Screenshot](https://github.com/user-attachments/assets/850c13a7-2bfb-4f28-b520-e5371cb4e946)

### Solution
- Added step-by-step instructions for setting up and exporting the AOS keyfile.
- Included links to relevant resources for further guidance.
- Linked installation instructions, available [here](https://cookbook_ao.g8way.io/welcome/getting-started.html#installing-aos).

![Solution Screenshot](https://github.com/user-attachments/assets/66a88d44-12b9-474f-b865-1db83ec67c7c)

### Verification and Checklist
- [x] Followed the [CONTRIBUTING.md](https://github.com/Autonomous-Finance/ao-starter-kit/blob/main/.github/CONTRIBUTING.md).
- [x] Confirmed that all links and references are correct.
- [x] [Changeset](https://github.com/Autonomous-Finance/ao-starter-kit/blob/main/.github/CONTRIBUTING.md#versioning) changes are not required as it does not affect the public API or any bug.
